### PR TITLE
Fix to the handling of the Invalid SAML Ticket error

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -24,10 +24,10 @@ module OmniAuth
           @name_id  = response.name_id
           @attributes = response.attributes
 
-          return fail!(:invalid_ticket, 'Invalid SAML Ticket') if @name_id.nil? || @name_id.empty? || !response.valid?
+          return fail!(:invalid_ticket, OmniAuth::Error.new('Invalid SAML Ticket') if @name_id.nil? || @name_id.empty? || !response.valid?
           super
         rescue ArgumentError => e
-          fail!(:invalid_ticket, 'Invalid SAML Response')
+          fail!(:invalid_ticket, OmniAuth::Error.new('Invalid SAML Response'))
         end
       end
 


### PR DESCRIPTION
The fail! method requires an exception as the second parameter.
