### PR TITLE
Fix incompatibility with OmniAuth 1.1

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -24,10 +24,10 @@ module OmniAuth
           @name_id  = response.name_id
           @attributes = response.attributes
 
-          return fail!(:invalid_ticket, 'Invalid SAML Ticket') if @name_id.nil? || @name_id.empty? || !response.valid?
+          return fail!(:invalid_ticket, ValidationError.new('Invalid SAML Ticket')) if @name_id.nil? || @name_id.empty? || !response.valid?
           super
         rescue ArgumentError => e
-          fail!(:invalid_ticket, 'Invalid SAML Response')
+          fail!(:invalid_ticket, ValidationError.new('Invalid SAML Response'))
         end
       end
 

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec::Matchers.define :fail_with do |message|
   match do |actual|
-    actual.redirect? && actual.location == "/auth/failure?message=#{message}"
+    actual.redirect? && /\?.*message=#{message}/ === actual.location
   end
 end
 


### PR DESCRIPTION
The `OmniAuth::Strategy#fail!` method's second argument should be
an exception but we where passing a string. This wasn't noticed before
because earlier versions of OmniAuth just stashed that argument in the
env but now OmniAuth uses it to build a log message which fails.
