### PR TITLE
Fallback to omniauth callback url if assertion_consumer_service_url is not set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (0.9.2)
+    omniauth-saml (1.0.0)
       omniauth (~> 1.1)
       ruby-saml (~> 0.6)
 
@@ -26,8 +26,8 @@ GEM
       systemu (~> 2.5.0)
     method_source (0.8.1)
     multi_json (1.3.7)
-    nokogiri (1.5.5)
-    omniauth (1.1.1)
+    nokogiri (1.5.9)
+    omniauth (1.1.3)
       hashie (~> 1.2)
       rack
     pry (0.9.10)
@@ -45,7 +45,7 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
-    ruby-saml (0.6.0)
+    ruby-saml (0.7.2)
       canonix (= 0.1.1)
       nokogiri
       uuid (~> 2.3)
@@ -56,7 +56,7 @@ GEM
     slop (3.3.3)
     systemu (2.5.2)
     thor (0.16.0)
-    uuid (2.3.5)
+    uuid (2.3.7)
       macaddr (~> 1.0)
 
 PLATFORMS
@@ -66,7 +66,6 @@ DEPENDENCIES
   guard (~> 1.0)
   guard-rspec (~> 2.1)
   omniauth-saml!
-  pry
   rack-test (~> 0.6)
   rspec (~> 2.8)
   simplecov (~> 0.6)

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -10,8 +10,8 @@ module OmniAuth
 
       def request_phase
         request = Onelogin::Saml::Authrequest.new
+        options[:assertion_consumer_service_url] ||= callback_url
         settings = Onelogin::Saml::Settings.new(options)
-
         redirect(request.create(settings))
       end
 


### PR DESCRIPTION
The assertion_consumer_service_url should be _optional_ since omniauth has conventions and builtin support for callback urls. 

This update will assign the callback url if the assertion_consumer_service_url is not set.
