### PR TITLE
Added support for additional SAML token fields to the info hash in the callback phase.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (1.1.0)
-      omniauth (~> 1.1)
+    omniauth-saml (1.2.0)
+      omniauth (~> 1.2)
       ruby-saml (~> 0.7.3)
 
 GEM
@@ -10,13 +10,13 @@ GEM
   specs:
     canonix (0.1.1)
     diff-lcs (1.2.4)
-    hashie (2.0.5)
-    macaddr (1.6.7)
+    hashie (3.2.0)
+    macaddr (1.7.1)
       systemu (~> 2.6.2)
     multi_json (1.3.7)
     nokogiri (1.5.11)
-    omniauth (1.2.1)
-      hashie (>= 1.2, < 3)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
       rack (~> 1.0)
     rack (1.5.2)
     rack-test (0.6.2)

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -29,8 +29,8 @@ module OmniAuth
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing")
         end
 
-        response = Onelogin::Saml::Response.new(request.params['SAMLResponse'], options)
-        response.settings = Onelogin::Saml::Settings.new(options)
+        @response = Onelogin::Saml::Response.new(request.params['SAMLResponse'], options)
+        @response.settings = Onelogin::Saml::Settings.new(options)
 
         @name_id = response.name_id
         @attributes = response.attributes
@@ -39,7 +39,7 @@ module OmniAuth
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing 'name_id'")
         end
 
-        response.validate!
+        @response.validate!
 
         super
       rescue OmniAuth::Strategies::SAML::ValidationError
@@ -69,7 +69,12 @@ module OmniAuth
           :name  => @attributes[:name],
           :email => @attributes[:email] || @attributes[:mail],
           :first_name => @attributes[:first_name] || @attributes[:firstname] || @attributes[:firstName],
-          :last_name => @attributes[:last_name] || @attributes[:lastname] || @attributes[:lastName]
+          :last_name => @attributes[:last_name] || @attributes[:lastname] || @attributes[:lastName],
+          :issuer => @response.issuer,
+          :session_index => @response.sessionindex,
+          :session_not_on_or_after  => @response.session_expires_at,
+          :not_before => @response.not_before,
+          :not_on_or_after => @response.not_on_or_after
         }
       end
 

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -75,7 +75,6 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it "should set the info hash values" do
-        puts auth_hash['info'].to_hash
         auth_hash['info'].to_hash.should == {
           'name'                    => 'Rajiv Manglani',
           'email'                   => 'user@example.com',

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -74,6 +74,21 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
         auth_hash['uid'].should == '_1f6fcf6be5e13b08b1e3610e7ff59f205fbd814f23'
       end
 
+      it "should set the info hash values" do
+        puts auth_hash['info'].to_hash
+        auth_hash['info'].to_hash.should == {
+          'name'                    => 'Rajiv Manglani',
+          'email'                   => 'user@example.com',
+          'first_name'              => 'Rajiv',
+          'last_name'               => 'Manglani',
+          'issuer'                  => 'http://localhost:9000/saml2/idp/metadata.php',
+          'session_index'           => '_17c45b5f1bb209798b06536ab9594723aa80634c58',
+          'session_not_on_or_after' => Time.utc(2012, 11, 9, 04, 39, 54),
+          'not_before'              => Time.utc(2012, 11, 8, 20, 39, 24),
+          'not_on_or_after'         => Time.utc(2012, 11, 8, 20, 44, 54)
+        }
+      end
+
       it "should set the raw info to all attributes" do
         auth_hash['extra']['raw_info'].to_hash.should == {
           'first_name'   => 'Rajiv',


### PR DESCRIPTION
This pull request is for Issue #28 on the PracticallyGreen/omniauth-saml repository. It adds an expanded number of info hash fields during the callback phase. The fields are pulled from the ruby-saml Response class. The updated fields include:

* issuer 
* session_index
* session_not_on_or_after
* response.session_expires_at
* not_before
* not_on_or_after

An additional test case was added to validate the new fields. 