### PR TITLE
Adding "settings" to Response Class at initialization to handle signing verification

### DIFF
--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
   end
 end

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -46,8 +46,8 @@ module OmniAuth
           options.idp_cert_fingerprint = fingerprint_exists
         end
 
-        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], options)
-        response.settings = OneLogin::RubySaml::Settings.new(options)
+        settings = OneLogin::RubySaml::Settings.new(options)
+        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], settings: settings)
         response.attributes['fingerprint'] = options.idp_cert_fingerprint
 
         @name_id = response.name_id

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.0.0'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.0'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'


### PR DESCRIPTION
According to Ruby SAML Doc in order to have signing validated you have to initialize the call OneLogin::RubySaml::Response using RubySaml Settings and do not this later.

Thanks.