### PR TITLE
Support custom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ The service provider metadata used to ease configuration of the SAML SP in the I
 
 * `:attribute_service_name` - Name for the attribute service. Defaults to `Required attributes`.
 
+* `:attribute_statements` - Used to map Attribute Names in a SAMLResponse to
+  entries in the OmniAuth [info hash](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later).
+  For example, if your SAMLResponse first name Attribute is named 'FirstName',
+  set this value to `{:first_name => ['FirstName']}`.
+
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 
 ## Devise Integration

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ The service provider metadata used to ease configuration of the SAML SP in the I
 
 * `:attribute_statements` - Used to map Attribute Names in a SAMLResponse to
   entries in the OmniAuth [info hash](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later).
-  For example, if your SAMLResponse first name Attribute is named 'FirstName',
-  set this value to `{:first_name => ['FirstName']}`.
+  For example, if your SAMLResponse contains an Attribute called 'EmailAddress',
+  specify `{:email => ['EmailAddress']}` to map it to the corresponding key in
+  the info hash.
 
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ The service provider metadata used to ease configuration of the SAML SP in the I
 * `:attribute_statements` - Used to map Attribute Names in a SAMLResponse to
   entries in the OmniAuth [info hash](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later).
   For example, if your SAMLResponse contains an Attribute called 'EmailAddress',
-  specify `{:email => ['EmailAddress']}` to map it to the corresponding key in
-  the info hash.
+  specify `{:email => ['EmailAddress']}` to map the Attribute to the
+  corresponding key in the info hash.  URI-named Attributes are also supported, e.g.
+  `{:email => ['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']}`.
 
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -114,7 +114,7 @@ module OmniAuth
           [key, attribute]
         end
 
-        found_attributes.to_h
+        Hash[found_attributes]
       end
 
       extra { { :raw_info => @attributes } }

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -15,6 +15,12 @@ module OmniAuth
         { name: 'last_name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Family name' }
       ]
       option :attribute_service_name, 'Required attributes'
+      option :attribute_statements, {
+        name: ["name"],
+        email: ["email", "mail"],
+        first_name: ["first_name", "firstname", "firstName"],
+        last_name: ["last_name", "lastname", "lastName"]
+      }
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url
@@ -103,15 +109,23 @@ module OmniAuth
       uid { @name_id }
 
       info do
-        {
-          :name  => @attributes[:name],
-          :email => @attributes[:email] || @attributes[:mail],
-          :first_name => @attributes[:first_name] || @attributes[:firstname] || @attributes[:firstName],
-          :last_name => @attributes[:last_name] || @attributes[:lastname] || @attributes[:lastName]
-        }
+        found_attributes = options.attribute_statements.map do |key, values|
+          attribute = find_attribute_by(values)
+          [key, attribute]
+        end
+
+        found_attributes.to_h
       end
 
       extra { { :raw_info => @attributes } }
+
+      def find_attribute_by(keys)
+        keys.each do |key|
+          return @attributes[key] if @attributes[key]
+        end
+
+        nil
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -153,6 +153,27 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
       it { should fail_with(:invalid_ticket) }
     end
+
+    context "when response has custom attributes" do
+      before :each do
+        saml_options[:idp_cert_fingerprint] = "3B:82:F1:F5:54:FC:A8:FF:12:B8:4B:B8:16:61:1D:E4:8E:9B:E2:3C"
+        saml_options[:attribute_statements] = {
+          email: ["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],
+          first_name: ["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"],
+          last_name: ["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"]
+        }
+        post_xml :custom_attributes
+      end
+
+      it "should obey attribute statements mapping" do
+        auth_hash[:info].should == {
+          'first_name'   => 'Rajiv',
+          'last_name'    => 'Manglani',
+          'email'        => 'user@example.com',
+          'name'         => nil
+        }
+      end
+    end
   end
 
   describe 'GET /auth/saml/metadata' do

--- a/spec/support/custom_attributes.xml
+++ b/spec/support/custom_attributes.xml
@@ -1,0 +1,84 @@
+<samlp:Response 
+  xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" 
+  xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfx31eeaa1f-4f9a-7dbc-200c-4d556bac4fc9" Version="2.0" IssueInstant="2012-11-08T20:39:54Z" Destination="http://localhost:9080/auth/saml/callback" InResponseTo="_5ad34590-0c12-0130-2b62-109add67ce12">
+  <saml:Issuer>http://localhost:9000/saml2/idp/metadata.php</saml:Issuer>
+  <ds:Signature 
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#pfx31eeaa1f-4f9a-7dbc-200c-4d556bac4fc9">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestValue>f311FuR1PE2NXct21G5z8Ka/Gfo=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>3vfxoQn2PLwcYp1ApVLzlaZKEcHGjNZwLCBHkJC8oHYRonoL8v25iJ+5NFlWWXxSRG0SUA15coH+1gLMm6cF41h1sqHL/3wtiHQARnJUogqRUM76hTePHkSiJMUpr+ZD+Kb/l0DFct9/gJYkW1RPny9v8vdGNsMOQ/qnmk2xtII=</ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>MIICWDCCAcGgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBJMQswCQYDVQQGEwJmaTEQMA4GA1UECAwHVXVzaW1hYTERMA8GA1UECgwIRmxvd2RvY2sxFTATBgNVBAMMDGZsb3dkb2NrLmNvbTAeFw0xNTA5MTYwODUxMzdaFw0xNjA5MTUwODUxMzdaMEkxCzAJBgNVBAYTAmZpMRAwDgYDVQQIDAdVdXNpbWFhMREwDwYDVQQKDAhGbG93ZG9jazEVMBMGA1UEAwwMZmxvd2RvY2suY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+gQDntqPTJ4pRMWb5d17e3vImfpOg6Hzr3PFtbsqEyM8uXZAL713Q4oASum+VlKkPp5ybzJKrFYeEeCl4NOdwyuabrOTUoJLE/x6CpGBgU6o+Iavku+4CkDM5scEIguZgroVabvkwoZRs/2TgVbLhNWXwtLD7n1OvVhLI0L9ycK+RNQIDAQABo1AwTjAdBgNVHQ4EFgQU9t1/AYExhABNzP1+hCsuImUpkXAwHwYDVR0jBBgwFoAU9t1/AYExhABNzP1+hCsuImUpkXAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQCoMeBcLW6JTOdmygPXhYtS+c8t9RCg6Ki/XENOkZN98NgBRS7mAw+DZDezw5KTSH6k0DNw04MFAVZ64gaP2/ad9wHnsktH3mvbfQ8RY6XefSqNy0SuKIt03q26Xf3/vi1jrxn2JgnJG4V+AVR3DVoiiAfQF1ijQW2qhnZR3WCnWQ==</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="pfxe689248c-47f0-1e59-d2bb-546563043b6c" Version="2.0" IssueInstant="2012-11-08T20:39:54Z">
+    <saml:Issuer>http://localhost:9000/saml2/idp/metadata.php</saml:Issuer>
+    <ds:Signature 
+      xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+        <ds:Reference URI="#pfxe689248c-47f0-1e59-d2bb-546563043b6c">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+          <ds:DigestValue>20g3ohE5p7icP5ZQ3CSRkSpGaME=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>m9+Hq+RDNJyKWGsqCpqmkXt/6dz/NQUkdzeF5YHSezVuLFJajB+QC2aSeyic5H5Z0LBkQscjZ1sgme7Hyeo+ZvBgDrBejP6bZfMyaNrET6JTKXxXnrSI0txEL7oXGgnWLJX+oTUWLJgO+PHAUGeS9AgbKcBTQjaW7aW8uh4WtJg=</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICWDCCAcGgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBJMQswCQYDVQQGEwJmaTEQMA4GA1UECAwHVXVzaW1hYTERMA8GA1UECgwIRmxvd2RvY2sxFTATBgNVBAMMDGZsb3dkb2NrLmNvbTAeFw0xNTA5MTYwODUxMzdaFw0xNjA5MTUwODUxMzdaMEkxCzAJBgNVBAYTAmZpMRAwDgYDVQQIDAdVdXNpbWFhMREwDwYDVQQKDAhGbG93ZG9jazEVMBMGA1UEAwwMZmxvd2RvY2suY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+gQDntqPTJ4pRMWb5d17e3vImfpOg6Hzr3PFtbsqEyM8uXZAL713Q4oASum+VlKkPp5ybzJKrFYeEeCl4NOdwyuabrOTUoJLE/x6CpGBgU6o+Iavku+4CkDM5scEIguZgroVabvkwoZRs/2TgVbLhNWXwtLD7n1OvVhLI0L9ycK+RNQIDAQABo1AwTjAdBgNVHQ4EFgQU9t1/AYExhABNzP1+hCsuImUpkXAwHwYDVR0jBBgwFoAU9t1/AYExhABNzP1+hCsuImUpkXAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQCoMeBcLW6JTOdmygPXhYtS+c8t9RCg6Ki/XENOkZN98NgBRS7mAw+DZDezw5KTSH6k0DNw04MFAVZ64gaP2/ad9wHnsktH3mvbfQ8RY6XefSqNy0SuKIt03q26Xf3/vi1jrxn2JgnJG4V+AVR3DVoiiAfQF1ijQW2qhnZR3WCnWQ==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="sample-saml-strategy" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_1f6fcf6be5e13b08b1e3610e7ff59f205fbd814f23</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2012-11-08T20:44:54Z" Recipient="http://localhost:9080/auth/saml/callback" InResponseTo="_5ad34590-0c12-0130-2b62-109add67ce12"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2012-11-08T20:39:24Z" NotOnOrAfter="2012-11-08T20:44:54Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>sample-saml-strategy</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2012-11-08T20:39:54Z" SessionNotOnOrAfter="2012-11-09T04:39:54Z" SessionIndex="_17c45b5f1bb209798b06536ab9594723aa80634c58">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+        <saml:AttributeValue xsi:type="xs:string">Rajiv</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname">
+        <saml:AttributeValue xsi:type="xs:string">Manglani</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+        <saml:AttributeValue xsi:type="xs:string">user@example.com</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
This PR replaces #51. Here is @OsQu's description from that PR:

> Attribute statements might not always have a Name="firstName" attribute, and modifying the idp to support can be an exhausting task (e.g. ADFS).
> 
> Now one can give attribute_statements option, which contains a mapping from statements to an info hash. For example the default mapping is following:

> ```
>   option :attribute_statements, {
    name: ["name"],
    email: ["email", "mail"],
    first_name: ["first_name", "firstname", "firstName"],
    last_name: ["last_name", "lastname", "lastName"]
  }
> ```
> This we can support whatever weird configurations the other end might have, without hard-coding them directly to the source.

Closes #45, #49, #51