### PR TITLE
docs: move license from README.md to LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+# License
+
+Copyright © 2016 Omniauth-SAML maintainers
+
+Copyright © 2011-2014 [Practically Green, Inc.](http://www.practicallygreen.com/).
+
+All rights reserved. Released under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [codeclimate]: https://codeclimate.com/github/omniauth/omniauth-saml
 [coveralls]: https://coveralls.io/r/omniauth/omniauth-saml
 
-A generic SAML strategy for OmniAuth.
+A generic SAML strategy for OmniAuth available under the [MIT License](LICENSE.md)
 
 https://github.com/omniauth/omniauth-saml
 
@@ -142,27 +142,3 @@ Then follow Devise's general [OmniAuth tutorial](https://github.com/plataformate
 ## Authors
 
 Authored by [Rajiv Aaron Manglani](http://www.rajivmanglani.com/), Raecoo Cao, Todd W Saxton, Ryan Wilcox, Steven Anderson, Nikos Dimitrakopoulos, Rudolf Vriend and [Bruno Pedro](http://brunopedro.com/).
-
-## License
-
-Copyright © 2016 Omniauth-SAML maintainers
-Copyright © 2011-2014 [Practically Green, Inc.](http://www.practicallygreen.com/).
-All rights reserved. Released under the MIT license.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov', '~> 0.6'
   gem.add_development_dependency 'rack-test', '~> 0.6'
 
-  gem.files         = ['README.md', 'CHANGELOG.md'] + Dir['lib/**/*.rb']
+  gem.files         = ['README.md', 'CHANGELOG.md', 'LICENSE.md'] + Dir['lib/**/*.rb']
   gem.test_files    = Dir['spec/**/*.rb']
   gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
A widely adopted best practice is having a LICENSE.md file, so I've moved the license out from README.md to a dedicated file.
