### PR TITLE
Fixed specs to make them compatible with `ruby-saml` 1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 spec/support/example_private_key.pem
 /gemfiles/*.lock
+.idea/

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -16,7 +16,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
   let(:auth_hash){ last_request.env['omniauth.auth'] }
   let(:saml_options) do
     {
-      :assertion_consumer_service_url     => "http://localhost:3000/auth/saml/callback",
+      :assertion_consumer_service_url     => "http://localhost:9080/auth/saml/callback",
       :idp_sso_target_url                 => "https://idp.sso.example.com/signon/29490",
       :idp_cert_fingerprint               => "C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB",
       :idp_sso_target_url_runtime_params  => {:original_param_key => :mapped_param_key},


### PR DESCRIPTION
Fixed the `saml-spec.rb` file and added the `.idea/` folder to the `.gitignore` file for people that use RubyMine as their preferred IDE, like me.