### PR TITLE
chore: remove ruby 1.8.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: ruby
 script: bundle exec rspec
 matrix:
   include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/ruby-1.8.7.gemfile
     - rvm: 1.9.3
       gemfile: Gemfile
     - rvm: 2.0.0
@@ -17,8 +15,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.3.0
       gemfile: Gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby-1.8.7.gemfile
     - rvm: jruby-19mode
       gemfile: Gemfile
     - rvm: jruby-head
@@ -28,8 +24,6 @@ matrix:
     - rvm: ruby-head
       gemfile: Gemfile
   allow_failures:
-    - rvm: 1.8.7
-    - rvm: jruby-18mode
     - rvm: jruby-head
     - rvm: rbx-2
     - rvm: ruby-head

--- a/gemfiles/ruby-1.8.7.gemfile
+++ b/gemfiles/ruby-1.8.7.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'nokogiri', '~> 1.5.10'
-gem 'hashie', '~> 2.0.5'
-
-gemspec :path => '../'


### PR DESCRIPTION
This closes #70