### PR TITLE
Extract metadata route logic to a separate method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 script: bundle exec rspec
+before_install: gem update bundler
 matrix:
   include:
     - rvm: 1.9.3

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -96,8 +96,12 @@ module OmniAuth
         Digest::SHA1.hexdigest(cert.to_der).upcase.scan(/../).join(':')
       end
 
+      def on_metadata_path?
+        on_path?("#{request_path}/metadata")
+      end
+
       def other_phase
-        if on_path?("#{request_path}/metadata")
+        if on_metadata_path?
           # omniauth does not set the strategy on the other_phase
           @env['omniauth.strategy'] ||= self
           setup_phase

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -218,4 +218,8 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       last_response.body.should match /Required attributes/
     end
   end
+
+  it 'implements #on_metadata_path?' do
+    expect(described_class.new(nil)).to respond_to(:on_metadata_path?)
+  end
 end


### PR DESCRIPTION
This is a trivial change that will make it easier for [omniauth-multi-provider-saml](https://github.com/salsify/omniauth-multi-provider-saml) to override the method, so it can properly route `/auth/saml/:provider/metadata` to display per-provider metadata.

Some background: for multi-provider SAML, each SAML provider has a unique identifier that scopes all the omniauth paths for it -- e.g. `/auth/saml/myprovider/callback`, `/auth/saml/otherguys/callback`. But the metadata route is broken, as this gem hard-codes the expected path to just `/auth/saml/metadata`. So short of copying the entire `other_phase` method, there's no good workaround (multi-provider-saml passes in a proc value for `request_path`, which `Omniauth::Strategy` [just ignores](https://github.com/intridea/omniauth/blob/32c4165919ab34189faa443cea66dfb11ba4fbff/lib/omniauth/strategy.rb#L380) for literal path comparison).

I think this PR is the easiest way to address the problem, though it'll need to be accompanied by a gem release so that multi-provider-saml can actually depend on it.