### PR TITLE
Register subclasses with OmniAuth.strategies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,8 @@ matrix:
       gemfile: Gemfile
     - rvm: ruby-head
       gemfile: Gemfile
+  allow_failures:
+    - rvm: jruby-head
+    - rvm: ruby-head
   fast_finish: true
 sudo: false

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -6,6 +6,10 @@ module OmniAuth
     class SAML
       include OmniAuth::Strategy
 
+      def self.inherited(subclass)
+        OmniAuth::Strategy.included(subclass)
+      end
+
       OTHER_REQUEST_OPTIONS = [:skip_conditions, :allowed_clock_drift, :matches_request_id, :skip_subject_confirmation].freeze
 
       option :name_identifier_format, nil

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -222,4 +222,11 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
   it 'implements #on_metadata_path?' do
     expect(described_class.new(nil)).to respond_to(:on_metadata_path?)
   end
+
+  describe 'subclass behavior' do
+    it 'registers subclasses in OmniAuth.strategies' do
+      subclass = Class.new(described_class)
+      expect(OmniAuth.strategies).to include(described_class, subclass)
+    end
+  end
 end


### PR DESCRIPTION
This PR updates `OmniAuth::Strategies::SAML` to register any subclasses as strategies with OmniAuth. This parallels what's done in the `omniauth-oauth2` gem (cf. [here](https://github.com/intridea/omniauth-oauth2/blob/26152673224aca5c3e918bcc83075dbb0659717f/lib/omniauth/strategies/oauth2.rb#L17-L19)).