### PR TITLE
feat: Add the soft option to SAML options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ The service provider metadata used to ease configuration of the SAML SP in the I
 
 * `:uid_attribute` - Attribute that uniquely identifies the user. If unset, the name identifier returned by the IdP is used.
 
+* `:soft` - Used to enable/disable the soft mode. When is set `false` (the
+  default), the SAML validation errors will raise an exception. Setting this to `true` is useful when testing or in environment where you don't want to set up a real SAML server with signed requests. **You should never do this in a production environment**
+
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 
 ## Devise Integration

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -10,7 +10,7 @@ module OmniAuth
         OmniAuth::Strategy.included(subclass)
       end
 
-      OTHER_REQUEST_OPTIONS = [:skip_conditions, :allowed_clock_drift, :matches_request_id, :skip_subject_confirmation].freeze
+      OTHER_REQUEST_OPTIONS = [:skip_conditions, :allowed_clock_drift, :matches_request_id, :skip_subject_confirmation, :soft].freeze
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
@@ -177,7 +177,7 @@ module OmniAuth
       def handle_response(raw_response, opts, settings)
         response = OneLogin::RubySaml::Response.new(raw_response, opts.merge(settings: settings))
         response.attributes["fingerprint"] = options.idp_cert_fingerprint
-        response.soft = false
+        response.soft = opts[:soft] || false
 
         response.is_valid?
         @name_id = response.name_id

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -186,6 +186,37 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       it { should fail_with(:invalid_ticket) }
     end
 
+    context "when run with soft option" do
+      before :each do
+        saml_options[:soft] = true
+      end
+
+      context "when the fingerprint is invalid" do
+        before :each do
+          saml_options[:idp_cert_fingerprint] = "00:00:00:00:00:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB"
+          post_xml
+        end
+
+        it { should_not fail_with(:invalid_ticket) }
+      end
+
+      context "when the digest is invalid" do
+        before :each do
+          post_xml :digest_mismatch
+        end
+
+        it { should_not fail_with(:invalid_ticket) }
+      end
+
+      context "when the signature is invalid" do
+        before :each do
+          post_xml :invalid_signature
+        end
+
+        it { should_not fail_with(:invalid_ticket) }
+      end
+    end
+
     context "when response has custom attributes" do
       before :each do
         saml_options[:idp_cert_fingerprint] = "3B:82:F1:F5:54:FC:A8:FF:12:B8:4B:B8:16:61:1D:E4:8E:9B:E2:3C"


### PR DESCRIPTION
When setting up the providr you can now set the soft option.

  provider :saml,
    issuer: 'Example',
    idp_sso_target_url: 'example.com/sso',
    idp_cert: 'mycert',
    soft: true

The default is still false, but you can now over-ride this to turn
off raising of SAML validation errors.

This is useful when testing or in environment where you don't really
want to set up a real SAML server with signed requests etc.
