### PR TITLE
Update ruby-saml to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ https://github.com/omniauth/omniauth-saml
 
 ## 1.6.0 (Unreleased)
 * Ensure that subclasses of `OmniAuth::Stategies::SAML` are registered with OmniAuth as strategies (https://github.com/omniauth/omniauth-saml/pull/95)
+* Update ruby-saml to 1.3 to address [CVE-2016-5697](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5697) (Signature wrapping attacks)
 
 ## 1.5.0 (2016-02-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ A generic SAML strategy for OmniAuth.
 
 https://github.com/omniauth/omniauth-saml
 
+## 1.6.0 (Unreleased)
+* Ensure that subclasses of `OmniAuth::Stategies::SAML` are registered with OmniAuth as strategies (https://github.com/omniauth/omniauth-saml/pull/95)
+
 ## 1.5.0 (2016-02-25)
 
 * Initialize OneLogin::RubySaml::Response instance with settings

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/omniauth/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.3'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.1', '>= 1.1.1'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.3'
 
   gem.add_development_dependency 'rspec', '~>3.4'
   gem.add_development_dependency 'simplecov', '~> 0.11'


### PR DESCRIPTION
This PR updates `ruby-saml` to 1.3.0 to address [CVE-2016-5697](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5697) signature wrapping attacks as [recommended](https://github.com/omniauth/omniauth-saml/issues/96#issuecomment-228411928) by `ruby-saml` maintainer @pitbulk.