### PR TITLE
feat: added the response object to the extra['response_object']

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ end
 
 For IdP-initiated SSO, users should directly access the IdP SSO target URL. Set the `href` of your application's login link to the value of `idp_sso_target_url`. For SP-initiated SSO, link to `/auth/saml`.
 
+A `OneLogin::RubySaml::Response` object is added to the `env['omniauth.auth']` extra attribute, so we can use it in the controller via `env['omniauth.auth'].extra.response_object`
+
 ## Metadata
 
 The service provider metadata used to ease configuration of the SAML SP in the IdP can be retrieved from `http://example.com/auth/saml/metadata`. Send this URL to the administrator of the IdP.

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -76,6 +76,7 @@ module OmniAuth
 
         @name_id = response.name_id
         @attributes = response.attributes
+        @response_object = response
 
         if @name_id.nil? || @name_id.empty?
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing 'name_id'")
@@ -135,7 +136,7 @@ module OmniAuth
         Hash[found_attributes]
       end
 
-      extra { { :raw_info => @attributes } }
+      extra { { :raw_info => @attributes, :response_object =>  @response_object } }
 
       def find_attribute_by(keys)
         keys.each do |key|

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -114,6 +114,10 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
           'fingerprint'  => saml_options[:idp_cert_fingerprint]
         }
       end
+
+      it "should set the response_object to the response object from ruby_saml response" do
+        auth_hash['extra']['response_object'].should be_kind_of(OneLogin::RubySaml::Response)
+      end
     end
 
     context "when fingerprint is empty and there's a fingerprint validator" do


### PR DESCRIPTION
feat: added the Ruby-saml response object to the extra attribute, so we can use it in the controller via "env['omniauth.auth'].extra.response_object"