### PR TITLE
fix: saved validation error to session so we can reuse after redirect

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -82,10 +82,12 @@ module OmniAuth
         end
 
         super
-      rescue OmniAuth::Strategies::SAML::ValidationError
-        fail!(:invalid_ticket, $!)
-      rescue OneLogin::RubySaml::ValidationError
-        fail!(:invalid_ticket, $!)
+      rescue OmniAuth::Strategies::SAML::ValidationError => exception
+        session['saml_error'] = exception.to_s
+        fail!(:invalid_ticket, exception)
+      rescue OneLogin::RubySaml::ValidationError => exception
+        session['saml_error'] = exception.to_s
+        fail!(:invalid_ticket, exception)
       end
 
       # Obtain an idp certificate fingerprint from the response.

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -161,6 +161,12 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it { should fail_with(:invalid_ticket) }
+
+      it "should set session['saml_error'] but not env['omniauth.error'] after redirect" do
+        follow_redirect!
+        last_request.env['omniauth.error'].should be_nil
+        last_request.env["rack.session"]["saml_error"].should == "Fingerprint mismatch"
+      end
     end
 
     context "when the digest is invalid" do
@@ -169,6 +175,12 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it { should fail_with(:invalid_ticket) }
+
+      it "should set session['saml_error'] but not env['omniauth.error'] after redirect" do
+        follow_redirect!
+        last_request.env['omniauth.error'].should be_nil
+        last_request.env["rack.session"]["saml_error"].should == "Digest mismatch"
+      end
     end
 
     context "when the signature is invalid" do
@@ -177,6 +189,12 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it { should fail_with(:invalid_ticket) }
+
+      it "should set session['saml_error'] but not env['omniauth.error'] after redirect" do
+        follow_redirect!
+        last_request.env['omniauth.error'].should be_nil
+        last_request.env["rack.session"]["saml_error"].should == "Key validation error"
+      end
     end
 
     context "when response has custom attributes" do


### PR DESCRIPTION
When there is a validation error on the SAML response, Omniauth will redirect the request to the failure endpoint. In the case of redirection, everything saved in the "env" variable is lost because it only exist in the current request. So in order to access the error message in the failure endpoint, we need to use session to save the error message. 