### PR TITLE
chore: Add conventional changelog generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 spec/support/example_private_key.pem
 /gemfiles/*.lock
 .idea/
+.bundle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
-# OmniAuth SAML Version History
-
-A generic SAML strategy for OmniAuth.
-
-https://github.com/omniauth/omniauth-saml
-
-## 1.6.0 (2016-06-27)
+<a name="v1.6.0"></a>
+### v1.6.0 (2016-06-27)
 * Ensure that subclasses of `OmniAuth::Stategies::SAML` are registered with OmniAuth as strategies (https://github.com/omniauth/omniauth-saml/pull/95)
 * Update ruby-saml to 1.3 to address [CVE-2016-5697](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5697) (Signature wrapping attacks)
 
-## 1.5.0 (2016-02-25)
+<a name="v1.5.0"></a>
+### v1.5.0 (2016-02-25)
 
 * Initialize OneLogin::RubySaml::Response instance with settings
 * Adding "settings" to Response Class at initialization to handle signing verification
@@ -18,56 +14,67 @@ https://github.com/omniauth/omniauth-saml
 * Call validation earlier to get real error instead of 'response missing name_id'
 * Avoid mutation of the options hash during requests and callbacks
 
-## 1.4.2 (2016-02-09)
+<a name="v1.4.2"></a>
+### v1.4.2 (2016-02-09)
 
 * update ruby-saml to 1.1
 
-## 1.4.1 (2015-08-09)
+<a name="v1.4.1"></a>
+### v1.4.1 (2015-08-09)
 
 * Configurable attribute_consuming_service
 
-## 1.4.0 (2015-07-23)
+<a name="v1.4.0"></a>
+### v1.4.0 (2015-07-23)
 
 * update ruby-saml to 1.0.0
 
-## 1.3.1 (2015-02-26)
+<a name="v1.3.1"></a>
+### v1.3.1 (2015-02-26)
 
 * Added missing fingerprint key check
 * Expose fingerprint on the auth_hash
 
-## 1.3.0 (2015-01-23)
+<a name="v1.3.0"></a>
+### v1.3.0 (2015-01-23)
 
 * add `idp_cert_fingerprint_validator` option
 
-## 1.2.0 (2014-03-19)
+<a name="v1.2.0"></a>
+### v1.2.0 (2014-03-19)
 
 * provide SP metadata at `/auth/saml/metadata`
 
-## 1.1.0 (2013-11-07)
+<a name="v1.1.0"></a>
+### v1.1.0 (2013-11-07)
 
 * no longer set a default `name_identifier_format`
 * pass strategy options to the underlying ruby-saml library
 * fallback to omniauth callback url if `assertion_consumer_service_url` is not set
 * add `idp_sso_target_url_runtime_params` option
 
-## 1.0.0 (2012-11-12)
+<a name="v1.0.0"></a>
+### v1.0.0 (2012-11-12)
 
 * remove SAML code and port to ruby-saml gem
 * fix incompatibility with OmniAuth 1.1
 
-## 0.9.2 (2012-03-30)
+<a name="v0.9.2"></a>
+### v0.9.2 (2012-03-30)
 
 * validate the SAML response
 * 100% test coverage
 * now requires ruby 1.9.2+
 
-## 0.9.1 (2012-02-23)
+<a name="v0.9.1"></a>
+### v0.9.1 (2012-02-23)
 
 * return first and last name in the info hash
 * no longer use LDAP OIDs for name and email selection
 * return SAML attributes as the omniauth raw_info hash
 
-## 0.9.0 (2012-02-14)
+<a name="v0.9.0"></a>
+### v0.9.0 (2012-02-14)
 
 * initial release
 * extracts commits from omniauth 0-3-stable branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,12 @@ feat: create initial CONTRIBUTING.md
 This closes #73
 ```
 
-> **NOTE:** [CHANGELOG.md](CHANGELOG.md) is generated based on the commits.
+## Release process
+
+Example for version `v1.7.0`
+
+1. Bump the version in `lib/omniauth-saml/version.rb`
+1. Update [CHANGELOG.md](CHANGELOG.md) with `bundle exec conventional-changelog version=v1.7.0 since_version=v1.6.0`
+1. Commit all your changes
+1. Tag the latest commit with `git tag v1.7.0`
+1. Contact the maintainers

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~>3.4'
   gem.add_development_dependency 'simplecov', '~> 0.11'
   gem.add_development_dependency 'rack-test', '~> 0.6', '>= 0.6.3'
+  gem.add_development_dependency 'conventional-changelog', '~> 1.2'
 
   gem.files         = ['README.md', 'CHANGELOG.md', 'LICENSE.md'] + Dir['lib/**/*.rb']
   gem.test_files    = Dir['spec/**/*.rb']


### PR DESCRIPTION
This is a spike for @bufferoverflow to see how we can integrate a [conventional changelog generator](https://github.com/conventional-changelog/conventional-changelog) into Ruby projects. Unfortunately there aren't many options, and I already ran into several issues with the [`conventional-changelog`](https://github.com/dcrec1/conventional-changelog-ruby) gem I'm using here:

- it's very basic, e.g. it only detects `feat` and `fix`
- the behaviour and CLI arguments are not very intuitive,  it's very easy to end up with commits listed under the wrong version header, and it's not possible to generate entries for previous releases either
- there's barely any error handling, wrong CLI arguments can result in an empty `CHANGELOG.md` file

I looked around a bit more for alternatives but couldn't find any other conventional changelog generators written in Ruby, only some older gems for "non-conventional" changelogs (e.g. [vclog](http://rubyworks.github.io/vclog/)). I also stumbled over [clog](http://blog.thoughtram.io/announcements/tools/2014/09/18/announcing-clog-a-conventional-changelog-generator-for-the-rest-of-us.html) which is written in Rust and is a full-featured port of the original NodeJS generator, but they only have Mac binaries so far and I guess a compiled language is overkill for this anyway :) So we'll probably look into improving the gem first.