### PR TITLE
Add issuer information to the metadata endpoint

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -115,6 +115,7 @@ module OmniAuth
           settings = OneLogin::RubySaml::Settings.new(options)
           if options.request_attributes.length > 0
             settings.attribute_consuming_service.service_name options.attribute_service_name
+            settings.issuer = options.issuer
             options.request_attributes.each do |attribute|
               settings.attribute_consuming_service.add_attribute attribute
             end

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -207,6 +207,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
   describe 'GET /auth/saml/metadata' do
     before do
+      saml_options[:issuer] = 'http://example.com/SAML'
       get '/auth/saml/metadata'
     end
 
@@ -220,6 +221,8 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       expect(last_response.body).to match /first_name/
       expect(last_response.body).to match /last_name/
       expect(last_response.body).to match /Required attributes/
+      expect(last_response.body).to match /entityID/
+      expect(last_response.body).to match /http:\/\/example.com\/SAML/
     end
   end
 


### PR DESCRIPTION
Without issuer information, which gets translated to an `entityID` in the metadata XML, some IdPs are unable to auto-configure themselves using the metadata endpoint, which is what it was meant for.

This pull requests adds this missing information.

Example XML

```xml
<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8104ed3c-6f3f-43a0-9709-fc5d285bb1c8" entityID="https://localhost:3443/">
<md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
<md:NameIDFormat>
urn:oasis:names:tc:SAML:2.0:nameid-format:transient
</md:NameIDFormat>
<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:3443/users/auth/saml/callback" index="0" isDefault="true"/>
<md:AttributeConsumingService index="1" isDefault="true">
<md:ServiceName xml:lang="en">Required attributes</md:ServiceName>
<md:RequestedAttribute FriendlyName="Email address" Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"/>
<md:RequestedAttribute FriendlyName="Full name" Name="name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"/>
<md:RequestedAttribute FriendlyName="Given name" Name="first_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"/>
<md:RequestedAttribute FriendlyName="Family name" Name="last_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"/>
</md:AttributeConsumingService>
</md:SPSSODescriptor>
</md:EntityDescriptor>
```

Related to https://gitlab.com/gitlab-org/gitlab-ce/issues/20433