### PR TITLE
Bump `ruby-saml` dependency to 1.4.0

### DIFF
--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/omniauth/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.3'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.3'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.4'
 
   gem.add_development_dependency 'rake', '>= 10', '< 12'
   gem.add_development_dependency 'rspec', '~>3.4'


### PR DESCRIPTION
We might want to add this for 1.7.0

cc @bufferoverflow @md5 