### PR TITLE
Add `uid_attribute` option to control the attribute used for the user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The service provider metadata used to ease configuration of the SAML SP in the I
   *Note*: All attributes can also be found in an array under `auth_hash[:extra][:raw_info]`,
   so this setting should only be used to map attributes that are part of the OmniAuth info hash schema.
 
+* `:uid_attribute` - Attribute that uniquely identifies the user. If unset, the name identifier returned by the IdP is used.
+
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 
 ## Devise Integration

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -28,6 +28,7 @@ module OmniAuth
         last_name: ["last_name", "lastname", "lastName"]
       }
       option :slo_default_relay_state
+      option :uid_attribute
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url
@@ -136,7 +137,17 @@ module OmniAuth
         end
       end
 
-      uid { @name_id }
+      uid do
+        if options.uid_attribute
+          ret = find_attribute_by([options.uid_attribute])
+          if ret.nil?
+            raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing '#{options.uid_attribute}' attribute")
+          end
+          ret
+        else
+          @name_id
+        end
+      end
 
       info do
         found_attributes = options.attribute_statements.map do |key, values|


### PR DESCRIPTION
Some SAML 2.0 IdPs use the transient name identifier format. In that case the name identifier changes for each login, which makes the name identifier unsuitable as a user identifier.

This patch introduces the `uid_attribute` option, that allows us to use a SAML 2.0 attribute as the user identifier instead of the name identifier.

Fixes issue #120.

*Note*: It was suggested in [this issue comment](https://github.com/omniauth/omniauth-saml/issues/120#issuecomment-260744835) that this patch should also make the name identifier optional. I decided to not do that, since that also has implications for logout. I therefore think that makes more sense as a separate patch.