### PR TITLE
feat: Add option :settings_object

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ Note that when [integrating with Devise](#devise-integration), the URL path will
 
 * `:uid_attribute` - Attribute that uniquely identifies the user. If unset, the name identifier returned by the IdP is used.
 
+* `:settings_object` - An instance of `OneLogin::RubySaml::Settings` which is then used for configuring
+  the [Ruby SAML gem](https://github.com/onelogin/ruby-saml#the-initialization-phase).
+   
+  This is especially useful together with the [metadata base configuration](https://github.com/onelogin/ruby-saml#metadata-based-configuration)
+  where you can parse the metadata provided by the IdP:
+  
+  ```ruby
+  provider :saml,
+    :assertion_consumer_service_url     => "consumer_service_url",
+    :issuer                             => "rails-application",
+    :settings_object                    => OneLogin::RubySaml::IdpMetadataParser.new.parse_remote("idp_metadata_url"),
+    :idp_sso_target_url_runtime_params  => {:original_request_param => :mapped_idp_param}
+  ```
+  
+  All other options given will be merged into the `settings_object` provided.
+
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 
 ## Devise Integration

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -33,51 +33,25 @@ module OmniAuth
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url
-        runtime_request_parameters = options.delete(:idp_sso_target_url_runtime_params)
-
-        additional_params = {}
-
-        if runtime_request_parameters
-          runtime_request_parameters.each_pair do |request_param_key, mapped_param_key|
-            additional_params[mapped_param_key] = request.params[request_param_key.to_s] if request.params.has_key?(request_param_key.to_s)
-          end
-        end
 
         authn_request = OneLogin::RubySaml::Authrequest.new
-        settings = OneLogin::RubySaml::Settings.new(options)
 
-        redirect(authn_request.create(settings, additional_params))
+        with_settings do |settings|
+          redirect(authn_request.create(settings, additional_params_for_authn_request))
+        end
       end
 
       def callback_phase
         raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing") unless request.params["SAMLResponse"]
 
-        # Call a fingerprint validation method if there's one
-        if options.idp_cert_fingerprint_validator
-          fingerprint_exists = options.idp_cert_fingerprint_validator[response_fingerprint]
-          unless fingerprint_exists
-            raise OmniAuth::Strategies::SAML::ValidationError.new("Non-existent fingerprint")
+        with_settings do |settings|
+          # Call a fingerprint validation method if there's one
+          validate_fingerprint(settings) if options.idp_cert_fingerprint_validator
+
+          handle_response(request.params["SAMLResponse"], options_for_response_object, settings) do
+            super
           end
-          # id_cert_fingerprint becomes the given fingerprint if it exists
-          options.idp_cert_fingerprint = fingerprint_exists
         end
-
-        settings = OneLogin::RubySaml::Settings.new(options)
-
-        # filter options to select only extra parameters
-        opts = options.select {|k,_| OTHER_REQUEST_OPTIONS.include?(k.to_sym)}
-
-        # symbolize keys without activeSupport/symbolize_keys (ruby-saml use symbols)
-        opts =
-          opts.inject({}) do |new_hash, (key, value)|
-            new_hash[key.to_sym] = value
-            new_hash
-          end
-
-        handle_response(request.params["SAMLResponse"], opts, settings) do
-          super
-        end
-
       rescue OmniAuth::Strategies::SAML::ValidationError
         fail!(:invalid_ticket, $!)
       rescue OneLogin::RubySaml::ValidationError
@@ -100,36 +74,13 @@ module OmniAuth
         if current_path.start_with?(request_path)
           @env['omniauth.strategy'] ||= self
           setup_phase
-          settings = OneLogin::RubySaml::Settings.new(options)
 
           if on_subpath?(:metadata)
-            # omniauth does not set the strategy on the other_phase
-            response = OneLogin::RubySaml::Metadata.new
-
-            if options.request_attributes.length > 0
-              settings.attribute_consuming_service.service_name options.attribute_service_name
-              settings.issuer = options.issuer
-
-              options.request_attributes.each do |attribute|
-                settings.attribute_consuming_service.add_attribute attribute
-              end
-            end
-
-            Rack::Response.new(response.generate(settings), 200, { "Content-Type" => "application/xml" }).finish
+            other_phase_for_metadata
           elsif on_subpath?(:slo)
-            if request.params["SAMLResponse"]
-              handle_logout_response(request.params["SAMLResponse"], settings)
-            elsif request.params["SAMLRequest"]
-              handle_logout_request(request.params["SAMLRequest"], settings)
-            else
-              raise OmniAuth::Strategies::SAML::ValidationError.new("SAML logout response/request missing")
-            end
+            other_phase_for_slo
           elsif on_subpath?(:spslo)
-            if options.idp_slo_target_url
-              redirect(generate_logout_request(settings))
-            else
-              Rack::Response.new("Not Implemented", 501, { "Content-Type" => "text/html" }).finish
-            end
+            other_phase_for_spslo
           else
             call_app!
           end
@@ -177,7 +128,7 @@ module OmniAuth
 
       def handle_response(raw_response, opts, settings)
         response = OneLogin::RubySaml::Response.new(raw_response, opts.merge(settings: settings))
-        response.attributes["fingerprint"] = options.idp_cert_fingerprint
+        response.attributes["fingerprint"] = settings.idp_cert_fingerprint
         response.soft = false
 
         response.is_valid?
@@ -262,6 +213,86 @@ module OmniAuth
         end
 
         logout_request.create(settings, RelayState: slo_relay_state)
+      end
+
+      def with_settings
+        yield OneLogin::RubySaml::Settings.new(options)
+      end
+
+      def validate_fingerprint(settings)
+        fingerprint_exists = options.idp_cert_fingerprint_validator[response_fingerprint]
+
+        unless fingerprint_exists
+          raise OmniAuth::Strategies::SAML::ValidationError.new("Non-existent fingerprint")
+        end
+
+        # id_cert_fingerprint becomes the given fingerprint if it exists
+        settings.idp_cert_fingerprint = fingerprint_exists
+      end
+
+      def options_for_response_object
+        # filter options to select only extra parameters
+        opts = options.select {|k,_| OTHER_REQUEST_OPTIONS.include?(k.to_sym)}
+
+        # symbolize keys without activeSupport/symbolize_keys (ruby-saml use symbols)
+        opts.inject({}) do |new_hash, (key, value)|
+          new_hash[key.to_sym] = value
+          new_hash
+        end
+      end
+
+      def other_phase_for_metadata
+        with_settings do |settings|
+          # omniauth does not set the strategy on the other_phase
+          response = OneLogin::RubySaml::Metadata.new
+
+          add_request_attributes_to(settings) if options.request_attributes.length > 0
+
+          Rack::Response.new(response.generate(settings), 200, { "Content-Type" => "application/xml" }).finish
+        end
+      end
+
+      def other_phase_for_slo
+        with_settings do |settings|
+          if request.params["SAMLResponse"]
+            handle_logout_response(request.params["SAMLResponse"], settings)
+          elsif request.params["SAMLRequest"]
+            handle_logout_request(request.params["SAMLRequest"], settings)
+          else
+            raise OmniAuth::Strategies::SAML::ValidationError.new("SAML logout response/request missing")
+          end
+        end
+      end
+
+      def other_phase_for_spslo
+        if options.idp_slo_target_url
+          with_settings do |settings|
+            redirect(generate_logout_request(settings))
+          end
+        else
+          Rack::Response.new("Not Implemented", 501, { "Content-Type" => "text/html" }).finish
+        end
+      end
+
+      def add_request_attributes_to(settings)
+        settings.attribute_consuming_service.service_name options.attribute_service_name
+        settings.issuer = options.issuer
+
+        options.request_attributes.each do |attribute|
+          settings.attribute_consuming_service.add_attribute attribute
+        end
+      end
+
+      def additional_params_for_authn_request
+        {}.tap do |additional_params|
+          runtime_request_parameters = options.delete(:idp_sso_target_url_runtime_params)
+
+          if runtime_request_parameters
+            runtime_request_parameters.each_pair do |request_param_key, mapped_param_key|
+              additional_params[mapped_param_key] = request.params[request_param_key.to_s] if request.params.has_key?(request_param_key.to_s)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -30,6 +30,7 @@ module OmniAuth
       option :slo_default_relay_state
       option :uid_attribute
       option :idp_slo_session_destroy, proc { |_env, session| session.clear }
+      option :settings_object, nil
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url
@@ -216,7 +217,17 @@ module OmniAuth
       end
 
       def with_settings
-        yield OneLogin::RubySaml::Settings.new(options)
+        if options[:settings_object]
+          settings = options.delete(:settings_object)
+
+          options.each do |key, value|
+            settings.public_send(:"#{key}=", value) if settings.respond_to?(:"#{key}=")
+          end
+        else
+          settings = OneLogin::RubySaml::Settings.new(options)
+        end
+
+        yield settings
       end
 
       def validate_fingerprint(settings)


### PR DESCRIPTION
This allows using the `OneLogin::RubySaml::IdpMetadataParser` for
configuration.

Other options given to the strategy will be merged into that settings
object. If `:settings_object` is `nil`, which is the default, a new
instance is created using the options given to the strategy.