### PR TITLE
fix: default assertion_consumer_service_url not set during callback

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -32,8 +32,6 @@ module OmniAuth
       option :idp_slo_session_destroy, proc { |_env, session| session.clear }
 
       def request_phase
-        options[:assertion_consumer_service_url] ||= callback_url
-
         authn_request = OneLogin::RubySaml::Authrequest.new
 
         with_settings do |settings|
@@ -212,6 +210,7 @@ module OmniAuth
       end
 
       def with_settings
+        options[:assertion_consumer_service_url] ||= callback_url
         yield OneLogin::RubySaml::Settings.new(options)
       end
 

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -157,6 +157,16 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
     end
 
+    context "when the assertion_consumer_service_url is the default" do
+      before :each do
+        saml_options.delete(:assertion_consumer_service_url)
+        OmniAuth.config.full_host = 'http://localhost:9080'
+        post_xml
+      end
+
+      it { is_expected.not_to fail_with(:invalid_ticket) }
+    end
+
     context "when there is no SAMLResponse parameter" do
       before :each do
         post '/auth/saml/callback'


### PR DESCRIPTION
Fix a bug where ruby-saml would fail SubjectConfirmation Recipient
validation when using the default assertion_consumer_service_url. The
url was not being set during the callback phase.

This closes #139