### PR TITLE
Update omniauth gem to 1.3.2 or later 1.3.x

### DIFF
--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency 'omniauth', '~> 1.3'
+  gem.add_runtime_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
   gem.add_runtime_dependency 'ruby-saml', '~> 1.4', '>= 1.4.3'
 
   gem.add_development_dependency 'rake', '>= 10', '< 12'


### PR DESCRIPTION
CVE-2017-18076 describes a bug in omniauth prior to version 1.3.2 (https://nvd.nist.gov/vuln/detail/CVE-2017-18076). This pull request upgrades the version of omniauth to 1.3.2 or later.