### PR TITLE
Update SLO internals to match latest ruby-saml API

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -161,11 +161,15 @@ module OmniAuth
         end
       end
 
-      def handle_logout_response(raw_response, settings)
+      def handle_logout_response(raw_response, settings, request)
         # After sending an SP initiated LogoutRequest to the IdP, we need to accept
         # the LogoutResponse, verify it, then actually delete our session.
 
-        logout_response = OneLogin::RubySaml::Logoutresponse.new(raw_response, settings, :matches_request_id => session["saml_transaction_id"])
+        response_options = build_logout_options(request).merge(
+          matches_request_id: session["saml_transaction_id"]
+        )
+
+        logout_response = OneLogin::RubySaml::Logoutresponse.new(raw_response, settings, response_options)
         logout_response.soft = false
         logout_response.validate
 
@@ -176,8 +180,12 @@ module OmniAuth
         redirect(slo_relay_state)
       end
 
-      def handle_logout_request(raw_request, settings)
-        logout_request = OneLogin::RubySaml::SloLogoutrequest.new(raw_request)
+      def handle_logout_request(raw_request, settings, request)
+        request_options = build_logout_options(request).merge(
+          settings: settings
+        )
+
+        logout_request = OneLogin::RubySaml::SloLogoutrequest.new(raw_request, request_options)
 
         if logout_request.is_valid? &&
           logout_request.name_id == session["saml_uid"]
@@ -192,6 +200,15 @@ module OmniAuth
         else
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML failed to process LogoutRequest")
         end
+      end
+
+      def build_logout_options(request)
+        {
+          get_params: request.GET.select { |k, _| k == "Signature" },
+          raw_get_params: Rack::Utils.parse_query(request.query_string, &:itself).select do |k, _|
+            %w(SAMLRequest SigAlg RelayState).include?(k)
+          end
+        }
       end
 
       # Create a SP initiated SLO: https://github.com/onelogin/ruby-saml#single-log-out
@@ -254,9 +271,9 @@ module OmniAuth
       def other_phase_for_slo
         with_settings do |settings|
           if request.params["SAMLResponse"]
-            handle_logout_response(request.params["SAMLResponse"], settings)
+            handle_logout_response(request.params["SAMLResponse"], settings, request)
           elsif request.params["SAMLRequest"]
-            handle_logout_request(request.params["SAMLRequest"], settings)
+            handle_logout_request(request.params["SAMLRequest"], settings, request)
           else
             raise OmniAuth::Strategies::SAML::ValidationError.new("SAML logout response/request missing")
           end

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.4', '>= 1.4.3'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.6'
 
   gem.add_development_dependency 'rake', '>= 10', '< 12'
   gem.add_development_dependency 'rspec', '~>3.4'


### PR DESCRIPTION
This PR updates the internals for constructing `OneLogin::RubySaml::Logoutresponse` and `OneLogin::RubySaml::SloLogoutrequest` instances to match the latest recommendations for `ruby-saml`. These changes help avoid character set encoding issues with IdPs using something other that UTF-8.

In addition, the `settings` object and signature are now being passed, allowing signatures to be validated on these requests and responses. Previously, the signatures were not being checked, so these interactions could be forged to fraudulently log out a user on the SP side.

Closes #147
