### PR TITLE
Whitelist more OneLogin::RubySaml::Response options

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -10,7 +10,10 @@ module OmniAuth
         OmniAuth::Strategy.included(subclass)
       end
 
-      OTHER_REQUEST_OPTIONS = [:skip_conditions, :allowed_clock_drift, :matches_request_id, :skip_subject_confirmation].freeze
+      OTHER_REQUEST_OPTIONS = [
+        :skip_conditions, :allowed_clock_drift, :matches_request_id,
+        :skip_subject_confirmation, :skip_destination, :skip_recipient_check
+      ].freeze
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}


### PR DESCRIPTION
I recently updated this gem in a repository where it was in use `v1.4.2`.
I noticed that https://github.com/omniauth/omniauth-saml/commit/4712e9990dbcb768286941d2f7f50e1b0e048d49 introduced a whitelist logic for options passed to the strategy:

```rb
# lib/omniauth/strategies/saml.rb
OTHER_REQUEST_OPTIONS = [:skip_conditions, :allowed_clock_drift, :matches_request_id, :skip_subject_confirmation].freeze
``` 

To this list, however, is excluding several options accepted by `OneLogin::RubySaml::Response`. Thus I added a couple of options that were missing and are used in [`ruby-saml`](https://github.com/onelogin/ruby-saml):

- `:skip_destination` https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/response.rb#L593-L615
- `: skip_recipient_check ` https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/response.rb#L744