### PR TITLE
Update readme for Single Logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ advertised in metadata by setting the `single_logout_service_url` config option)
 When using Devise as an authentication solution, the SP initiated flow can be integrated
 in the `SessionsController#destroy` action.
 
-For this to work it is important to preserve the `saml_uid` value before Devise
+For this to work it is important to preserve the `saml_uid` and `saml_session_index` value before Devise
 clears the session and redirect to the `/spslo` sub-path to initiate the single logout.
 
 Example `destroy` action in `sessions_controller.rb`:
@@ -214,17 +214,19 @@ class SessionsController < Devise::SessionsController
   # ...
 
   def destroy
-    # Preserve the saml_uid in the session
-    saml_uid = session["saml_uid"]
+    # Preserve the saml_uid and saml_session_index in the session
+    saml_uid = session['saml_uid']
+    saml_session_index = session['saml_session_index']
     super do
-      session["saml_uid"] = saml_uid
+      session['saml_uid'] = saml_uid
+      session['saml_session_index'] = saml_session_index
     end
   end
 
   # ...
 
   def after_sign_out_path_for(_)
-    if session['saml_uid'] && SAML_SETTINGS.idp_slo_target_url
+    if session['saml_uid'] && session['saml_session_index'] && SAML_SETTINGS.idp_slo_target_url
       user_saml_omniauth_authorize_path + "/spslo"
     else
       super


### PR DESCRIPTION
according to saml doc saml session index has to be preserved as well as saml uid
From http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf :

**4.4.3.2 Identity Provider Determines Session Participants**

_If the logout profile is initiated by an identity provider, or upon receiving a valid `<LogoutRequest>`
message, the identity provider processes the request as defined in [SAMLCore]. It **MUST** examine the
**identifier** and **`<SessionIndex>`** elements and determine the set of sessions to be terminated._
