### PR TITLE
Retrieves response available options from ruby-saml

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -10,10 +10,7 @@ module OmniAuth
         OmniAuth::Strategy.included(subclass)
       end
 
-      OTHER_REQUEST_OPTIONS = [
-        :skip_conditions, :allowed_clock_drift, :matches_request_id,
-        :skip_subject_confirmation, :skip_destination, :skip_recipient_check
-      ].freeze
+      RUBYSAML_RESPONSE_OPTIONS = OneLogin::RubySaml::Response::AVAILABLE_OPTIONS
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
@@ -234,7 +231,7 @@ module OmniAuth
 
       def options_for_response_object
         # filter options to select only extra parameters
-        opts = options.select {|k,_| OTHER_REQUEST_OPTIONS.include?(k.to_sym)}
+        opts = options.select {|k,_| RUBYSAML_RESPONSE_OPTIONS.include?(k.to_sym)}
 
         # symbolize keys without activeSupport/symbolize_keys (ruby-saml use symbols)
         opts.inject({}) do |new_hash, (key, value)|

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.7'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.8'
 
   gem.add_development_dependency 'rake', '>= 10', '< 12'
   gem.add_development_dependency 'rspec', '~>3.4'


### PR DESCRIPTION
In https://github.com/onelogin/ruby-saml/pull/454 was introduced a whitelisting for allowed Response options.

In my previous pr https://github.com/omniauth/omniauth-saml/pull/159 I added one more option.
According to me, this whitelist introduced in 4712e9990dbcb768286941d2f7f50e1b0e048d49 should not be a responsibility of `omniauth-saml` but it should be provided out of the box by `ruby-saml`.  It looked like @md5 agreed on this point (https://github.com/omniauth/omniauth-saml/pull/159#issuecomment-376233630)

Since `'ruby-saml' ~>1.8` integrated this change, I updated the dependency of this gem and retrieved response available options from it.
