### PR TITLE
Allow OmniAuth 2.0.0

### DIFF
--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.10.4'
+    VERSION = '2.0.0'
   end
 end

--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.10.3'
+    VERSION = '1.10.4'
   end
 end

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_runtime_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
+  gem.add_runtime_dependency 'omniauth', '>= 1.3.2', '< 3'
   gem.add_runtime_dependency 'ruby-saml', '~> 1.9'
 
   gem.add_development_dependency 'rake', '>= 12.3.3'

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_runtime_dependency 'omniauth', '>= 1.3.2', '< 3'
+  gem.add_runtime_dependency 'omniauth', '~> 2.0'
   gem.add_runtime_dependency 'ruby-saml', '~> 1.9'
 
   gem.add_development_dependency 'rake', '>= 12.3.3'

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :fail_with do |message|
   end
 end
 
-def post_xml(xml=:example_response, opts = {})
+def post_xml(xml = :example_response, opts = {})
   post "/auth/saml/callback", opts.merge({'SAMLResponse' => load_xml(xml)})
 end
 
@@ -34,10 +34,10 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
   end
   let(:strategy) { [OmniAuth::Strategies::SAML, saml_options] }
 
-  describe 'GET /auth/saml' do
+  describe 'POST /auth/saml' do
     context 'without idp runtime params present' do
       before do
-        get '/auth/saml'
+        post '/auth/saml'
       end
 
       it 'should get authentication page' do
@@ -51,7 +51,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
     context 'with idp runtime params' do
       before do
-        get '/auth/saml', 'original_param_key' => 'original_param_value', 'mapped_param_key' => 'mapped_param_value'
+        post '/auth/saml', 'original_param_key' => 'original_param_value', 'mapped_param_key' => 'mapped_param_value'
       end
 
       it 'should get authentication page' do
@@ -71,7 +71,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
       it 'should send the current callback_url as the assertion_consumer_service_url' do
         %w(foo.example.com bar.example.com).each do |host|
-          get "https://#{host}/auth/saml"
+          post "https://#{host}/auth/saml"
 
           expect(last_response).to be_redirect
 
@@ -89,7 +89,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
     end
 
     context 'when authn request signing is requested' do
-      subject { get '/auth/saml' }
+      subject { post '/auth/saml' }
 
       let(:private_key) { OpenSSL::PKey::RSA.new 2048 }
 
@@ -402,10 +402,10 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
     end
   end
 
-  describe 'GET /auth/saml/metadata' do
+  describe 'POST /auth/saml/metadata' do
     before do
       saml_options[:issuer] = 'http://example.com/SAML'
-      get '/auth/saml/metadata'
+      post '/auth/saml/metadata'
     end
 
     it 'should get SP metadata page' do
@@ -424,19 +424,19 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
   end
 
   context 'when hitting an unknown route in our sub path' do
-    before { get '/auth/saml/unknown' }
+    before { post '/auth/saml/unknown' }
 
     specify { expect(last_response.status).to eql 404 }
   end
 
   context 'when hitting a completely unknown route' do
-    before { get '/unknown' }
+    before { post '/unknown' }
 
     specify { expect(last_response.status).to eql 404 }
   end
 
   context 'when hitting a route that contains a substring match for the strategy name' do
-    before { get '/auth/saml2/metadata' }
+    before { post '/auth/saml2/metadata' }
 
     it 'should not set the strategy' do
       expect(last_request.env['omniauth.strategy']).to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'base64'
 TEST_LOGGER = Logger.new(StringIO.new)
 OneLogin::RubySaml::Logging.logger = TEST_LOGGER
 OmniAuth.config.logger = TEST_LOGGER
-OmniAuth.config.request_validation_phase = Proc.new
+OmniAuth.config.request_validation_phase = proc {}
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'base64'
 TEST_LOGGER = Logger.new(StringIO.new)
 OneLogin::RubySaml::Logging.logger = TEST_LOGGER
 OmniAuth.config.logger = TEST_LOGGER
+OmniAuth.config.request_validation_phase = Proc.new
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods


### PR DESCRIPTION
OmniAuth 2.0.0 only allows POST by default, which the tests here reflect now. 

As there is no _library_ code changed, I believe this should be fine as a patch version change. 

Edit: bumped it to a major after discussion externally

[OmniAuth 2.0.0 release notes](https://github.com/omniauth/omniauth/releases/tag/v2.0.0)

Closes #196 