### PR TITLE
Rename usage of deprecated SAML options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Use the SAML strategy as a middleware in your application:
 require 'omniauth'
 use OmniAuth::Strategies::SAML,
   :assertion_consumer_service_url     => "consumer_service_url",
-  :issuer                             => "issuer",
-  :idp_sso_target_url                 => "idp_sso_target_url",
-  :idp_sso_target_url_runtime_params  => {:original_request_param => :mapped_idp_param},
+  :sp_entity_id                       => "sp_entity_id",
+  :idp_sso_service_url                => "idp_sso_service_url",
+  :idp_sso_service_url_runtime_params => {:original_request_param => :mapped_idp_param},
   :idp_cert                           => "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----",
   :idp_cert_multi                     => {
                                            :signing => ["-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", ...],
@@ -58,9 +58,9 @@ and in `config/initializers/omniauth.rb`:
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :saml,
     :assertion_consumer_service_url     => "consumer_service_url",
-    :issuer                             => "rails-application",
-    :idp_sso_target_url                 => "idp_sso_target_url",
-    :idp_sso_target_url_runtime_params  => {:original_request_param => :mapped_idp_param},
+    :sp_entity_id                       => "rails-application",
+    :idp_sso_service_url                => "idp_sso_service_url",
+    :idp_sso_service_url_runtime_params => {:original_request_param => :mapped_idp_param},
     :idp_cert                           => "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----",
     :idp_cert_multi                     => {
                                              :signing => ["-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", ...],
@@ -72,7 +72,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-For IdP-initiated SSO, users should directly access the IdP SSO target URL. Set the `href` of your application's login link to the value of `idp_sso_target_url`. For SP-initiated SSO, link to `/auth/saml`.
+For IdP-initiated SSO, users should directly access the IdP SSO service URL. Set the `href` of your application's login link to the value of `idp_sso_service_url`. For SP-initiated SSO, link to `/auth/saml`.
 
 A `OneLogin::RubySaml::Response` object is added to the `env['omniauth.auth']` extra attribute, so we can use it in the controller via `env['omniauth.auth'].extra.response_object`
 
@@ -88,13 +88,13 @@ Note that when [integrating with Devise](#devise-integration), the URL path will
   received. If not provided, defaults to the OmniAuth callback URL (typically
   `http://example.com/auth/saml/callback`). Optional.
 
-* `:issuer` - The name of your application. Some identity providers might need this
+* `:sp_entity_id` - The name of your application. Some identity providers might need this
   to establish the identity of the service provider requesting the login. **Required**.
 
-* `:idp_sso_target_url` - The URL to which the authentication request should be sent.
+* `:idp_sso_service_url` - The URL to which the authentication request should be sent.
   This would be on the identity provider. **Required**.
 
-* `:idp_slo_target_url` - The URL to which the single logout request and response should
+* `:idp_slo_service_url` - The URL to which the single logout request and response should
   be sent. This would be on the identity provider. Optional.
 
 * `:idp_slo_session_destroy` - A proc that accepts up to two parameters (the rack environment, and the session),
@@ -106,7 +106,7 @@ Note that when [integrating with Devise](#devise-integration), the URL path will
   instance will be passed to this callable if it has an arity of 1. If the value is a string,
   the string will be returned, when the `RelayState` is called. Optional.
 
-* `:idp_sso_target_url_runtime_params` - A dynamic mapping of request params that exist
+* `:idp_sso_service_url_runtime_params` - A dynamic mapping of request params that exist
   during the request phase of OmniAuth that should to be sent to the IdP after a specific
   mapping. So for example, a param `original_request_param` with value `original_param_value`,
   could be sent to the IdP on the login request as `mapped_idp_param` with value
@@ -170,7 +170,7 @@ idp_metadata = idp_metadata_parser.parse_remote_to_hash("http://idp.example.com/
 use OmniAuth::Strategies::SAML,
   idp_metadata.merge(
     :assertion_consumer_service_url => "consumer_service_url",
-    :issuer                         => "issuer"
+    :sp_entity_id                   => "sp_entity_id"
   )
 ```
 
@@ -186,7 +186,7 @@ In `config/initializers/devise.rb`:
 Devise.setup do |config|
   config.omniauth :saml,
     idp_cert_fingerprint: 'fingerprint',
-    idp_sso_target_url: 'target_url'
+    idp_sso_service_url: 'idp_sso_service_url'
 end
 ```
 
@@ -196,7 +196,7 @@ Then follow Devise's general [OmniAuth tutorial](https://github.com/plataformate
 
 Single Logout can be Service Provider initiated or Identity Provider initiated.
 
-For SP initiated logout, the `idp_slo_target_url` option must be set to the logout url on the IdP,
+For SP initiated logout, the `idp_slo_service_url` option must be set to the logout url on the IdP,
 and users directed to `user_saml_omniauth_authorize_path + '/spslo'` after logging out locally. For
 IdP initiated logout, logout requests from the IdP should go to `/auth/saml/slo` (this can be
 advertised in metadata by setting the `single_logout_service_url` config option).
@@ -226,7 +226,7 @@ class SessionsController < Devise::SessionsController
   # ...
 
   def after_sign_out_path_for(_)
-    if session['saml_uid'] && session['saml_session_index'] && SAML_SETTINGS.idp_slo_target_url
+    if session['saml_uid'] && session['saml_session_index'] && SAML_SETTINGS.idp_slo_service_url
       user_saml_omniauth_authorize_path + "/spslo"
     else
       super

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -13,7 +13,7 @@ module OmniAuth
       RUBYSAML_RESPONSE_OPTIONS = OneLogin::RubySaml::Response::AVAILABLE_OPTIONS
 
       option :name_identifier_format, nil
-      option :idp_sso_target_url_runtime_params, {}
+      option :idp_sso_service_url_runtime_params, {}
       option :request_attributes, [
         { :name => 'email', :name_format => 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', :friendly_name => 'Email address' },
         { :name => 'name', :name_format => 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', :friendly_name => 'Full name' },
@@ -264,7 +264,7 @@ module OmniAuth
       end
 
       def other_phase_for_spslo
-        if options.idp_slo_target_url
+        if options.idp_slo_service_url
           with_settings do |settings|
             redirect(generate_logout_request(settings))
           end
@@ -275,7 +275,7 @@ module OmniAuth
 
       def add_request_attributes_to(settings)
         settings.attribute_consuming_service.service_name options.attribute_service_name
-        settings.issuer = options.issuer
+        settings.sp_entity_id = options.sp_entity_id
 
         options.request_attributes.each do |attribute|
           settings.attribute_consuming_service.add_attribute attribute
@@ -284,7 +284,7 @@ module OmniAuth
 
       def additional_params_for_authn_request
         {}.tap do |additional_params|
-          runtime_request_parameters = options.delete(:idp_sso_target_url_runtime_params)
+          runtime_request_parameters = options.delete(:idp_sso_service_url_runtime_params)
 
           if runtime_request_parameters
             runtime_request_parameters.each_pair do |request_param_key, mapped_param_key|

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -18,10 +18,10 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
     {
       :assertion_consumer_service_url     => "http://localhost:9080/auth/saml/callback",
       :single_logout_service_url          => "http://localhost:9080/auth/saml/slo",
-      :idp_sso_target_url                 => "https://idp.sso.example.com/signon/29490",
-      :idp_slo_target_url                 => "https://idp.sso.example.com/signoff/29490",
+      :idp_sso_service_url                => "https://idp.sso.example.com/signon/29490",
+      :idp_slo_service_url                => "https://idp.sso.example.com/signoff/29490",
       :idp_cert_fingerprint               => "C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB",
-      :idp_sso_target_url_runtime_params  => {:original_param_key => :mapped_param_key},
+      :idp_sso_service_url_runtime_params => {:original_param_key => :mapped_param_key},
       :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
       :request_attributes                 => [
         { :name => 'email', :name_format => 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', :friendly_name => 'Email address' },
@@ -306,7 +306,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
     context "when response is a logout response" do
       before :each do
-        saml_options[:issuer] = "https://idp.sso.example.com/metadata/29490"
+        saml_options[:sp_entity_id] = "https://idp.sso.example.com/metadata/29490"
 
         post "/auth/saml/slo", {
           SAMLResponse: load_xml(:example_logout_response),
@@ -323,7 +323,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       subject { post "/auth/saml/slo", params, "rack.session" => { "saml_uid" => "username@example.com" } }
 
       before :each do
-        saml_options[:issuer] = "https://idp.sso.example.com/metadata/29490"
+        saml_options[:sp_entity_id] = "https://idp.sso.example.com/metadata/29490"
       end
 
       let(:params) do
@@ -392,8 +392,8 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
         end
       end
 
-      it "should give not implemented without an idp_slo_target_url" do
-        saml_options.delete(:idp_slo_target_url)
+      it "should give not implemented without an idp_slo_service_url" do
+        saml_options.delete(:idp_slo_service_url)
         post "/auth/saml/spslo"
 
         expect(last_response.status).to eq 501
@@ -404,7 +404,7 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
 
   describe 'POST /auth/saml/metadata' do
     before do
-      saml_options[:issuer] = 'http://example.com/SAML'
+      saml_options[:sp_entity_id] = 'http://example.com/SAML'
       post '/auth/saml/metadata'
     end
 


### PR DESCRIPTION
I started using the `omniauth-saml` gem a few days ago. While implementing SSO and SLO functionality, I noticed a discrepancy between the settings of the current `ruby-saml` gem and this gem. This MR is intended to fix these:

## Deprecations
- `settings.issuer` has been renamed to `settings.sp_entity_id` with [`ruby-saml` 1.11.0](https://github.com/onelogin/ruby-saml/blob/master/CHANGELOG.md#1110-jul-24-2019)
- `settings.idp_sso_target_url` has been renamed to `settings.idp_sso_service_url` with [`ruby-saml` 1.12.0](https://github.com/onelogin/ruby-saml/blob/master/UPGRADING.md#upgrading-from-111x-to-1120)
- `settings.idp_slo_target_url` has been renamed to `settings.idp_slo_service_url` with [`ruby-saml` 1.12.0](https://github.com/onelogin/ruby-saml/blob/master/UPGRADING.md#upgrading-from-111x-to-1120)

While I would recommend all usages of this gem to update the settings, these changes should be backward compatible: Ruby-SAML has built-in support for using the new names to query information set with the deprecated methods:

- [`settings.sp_entity_id` might return the value of `settings.issuer`](https://github.com/onelogin/ruby-saml/blob/74c25457f48f7e6247c6a98d5711fd401a9d7e5e/lib/onelogin/ruby-saml/settings.rb#L117-L121)
- [`settings.idp_sso_service_url` might return the value of `settings.idp_sso_target_url`](https://github.com/onelogin/ruby-saml/blob/74c25457f48f7e6247c6a98d5711fd401a9d7e5e/lib/onelogin/ruby-saml/settings.rb#L79-L83)
- [`settings.idp_slo_service_url` might return the value of `settings.idp_slo_target_url`](https://github.com/onelogin/ruby-saml/blob/74c25457f48f7e6247c6a98d5711fd401a9d7e5e/lib/onelogin/ruby-saml/settings.rb#L85-L89)