### PR TITLE
Fix copy-pasteability of code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use OmniAuth::Strategies::SAML,
   :idp_cert_multi                     => {
                                            :signing => ["-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", ...],
                                            :encryption => []
-                                         }
+                                         },
   :idp_cert_fingerprint               => "E7:91:B2:E1:...",
   :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
   :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
@@ -64,7 +64,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :idp_cert_multi                     => {
                                              :signing => ["-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----", ...],
                                              :encryption => []
-                                           }
+                                           },
     :idp_cert_fingerprint               => "E7:91:B2:E1:...",
     :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
     :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"


### PR DESCRIPTION
Though this code is already not copy-pasteable as valid Ruby (due to the trailing `...` at the end of the `idp_cert_multi` array), that's at least obviously invalid and fast enough to fix.

This missing comma, however, causes parser errors that are less obvious and should be added!