### PR TITLE
fix: revert required_ruby_version to >=2.4 for 1.10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/omniauth/omniauth-saml
 ## Requirements
 
 * [OmniAuth](http://www.omniauth.org/) 1.3+
-* Ruby 2.4.x+
+* Ruby 2.1.x+
 
 ## Versioning
 

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'rajiv@alum.mit.edu'
   gem.homepage      = 'https://github.com/omniauth/omniauth-saml'
 
-  gem.required_ruby_version = '>= 2.4'
+  gem.required_ruby_version = '>= 2.1'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.3', '>= 1.3.2'
   gem.add_runtime_dependency 'ruby-saml', '~> 1.17'


### PR DESCRIPTION
In #228, it was noted that the required_ruby_version setting for the gem was bumped between gem version 2.1.0 to 2.1.1.  This was addressed in e9d5238 and released as gem version 2.1.2.

Earlier today, gem version 1.10.4 was released in order to resolve https://github.com/advisories/GHSA-cvp8-5r8g-fhvq for older rubies (ref #229), however this also highlights an earlier case in which the required_ruby_version setting was bumped during a patch release.  In this case, between gem version 1.10.1 and 1.10.2, required_ruby_version was bumped from >=2.1 to >=2.4.

With this PR, I am requesting that the required_ruby_version change made in gem version 1.10.2 be reverted in order to expand the ability for users stuck on the 1.10.x tree to resolve GHSA-cvp8-5r8g-fhvq.