### PR TITLE
feat: log errors on failed logout

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -190,7 +190,7 @@ module OmniAuth
           logout_response = OneLogin::RubySaml::SloLogoutresponse.new.create(settings, logout_request_id, nil, RelayState: slo_relay_state)
           redirect(logout_response)
         else
-          raise OmniAuth::Strategies::SAML::ValidationError.new("SAML failed to process LogoutRequest")
+          raise OmniAuth::Strategies::SAML::ValidationError.new("SAML failed to process LogoutRequest (#{logout_request.errors.join(', ')})")
         end
       end
 

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -346,12 +346,13 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       context "when request is an invalid logout request" do
         before :each do
           allow_any_instance_of(OneLogin::RubySaml::SloLogoutrequest).to receive(:is_valid?).and_return(false)
+          allow_any_instance_of(OneLogin::RubySaml::SloLogoutrequest).to receive(:errors).and_return(['Blank logout request'])
         end
 
         # TODO: Maybe this should not raise an exception, but return some 4xx error instead?
         it "should raise an exception" do
           expect { subject }.
-            to raise_error(OmniAuth::Strategies::SAML::ValidationError, 'SAML failed to process LogoutRequest')
+            to raise_error(OmniAuth::Strategies::SAML::ValidationError, 'SAML failed to process LogoutRequest (Blank logout request)')
         end
       end
 


### PR DESCRIPTION
This is a mini PR that merely includes actual error messages in logout request validation errors, giving people a chance to find out what's wrong when it's not working.